### PR TITLE
Add support for Investment transactions

### DIFF
--- a/banking_transaction.go
+++ b/banking_transaction.go
@@ -160,6 +160,11 @@ func (t *bankingTransaction) parseBankingTransactionField(line string,
 	}
 }
 
+func (t *bankingTransaction) parseTransactionTypeField(line string,
+						       config Config) error {
+	return t.parseBankingTransactionField(line, config)
+}
+
 // A Split is used to tag part of a transaction with a separate category and
 // description.
 type Split struct {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/dmjones/qif
 
+go 1.18
+
+require (
+	github.com/pkg/errors v0.8.0
+	github.com/stretchr/testify v1.2.2
+)
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
-	github.com/stretchr/testify v1.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/pkg/errors v0.8.0
+	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,5 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
-github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/investment_transaction.go
+++ b/investment_transaction.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package qif
+
+import "github.com/pkg/errors"
+import "github.com/shopspring/decimal"
+
+type InvestmentAction uint
+
+// Constant value for each Investment Action
+const (
+	ActionUndefined InvestmentAction = iota
+	ActionBuy
+	ActionBuyX
+	ActionSell
+	ActionSellX
+	ActionCGLong
+	ActionCGLongX
+	ActionCGMid
+	ActionCGMidX
+	ActionCGShort
+	ActionCGShortX
+	ActionDiv
+	ActionDivX
+	ActionIntInc
+	ActionIntIncX
+	ActionReInvDiv
+	ActionReInvInt
+	ActionReInvLg
+	ActionReInvMd
+	ActionReInvSh
+	ActionReprice
+	ActionXIn
+	ActionXOut
+	ActionMiscExp
+	ActionMiscExpX
+	ActionMiscInc
+	ActionMiscIncX
+	ActionMarginInt
+	ActionMarginIntX
+	ActionReturnCap
+	ActionReturnCapX
+	ActionStockSplit
+	ActionSharesOut
+	ActionSharesIn
+)
+
+var (
+    actionMap = map[string]InvestmentAction {
+	"Buy":      ActionBuy,
+	"BuyX":     ActionBuyX,
+	"Sell":     ActionSell,
+	"SellX":    ActionSellX,
+	"CGLong":   ActionCGLong,
+	"CGLongX":  ActionCGLongX,
+	"CGMid":    ActionCGMid,
+	"CGMidX":   ActionCGMidX,
+	"CGShort":  ActionCGShort,
+	"CGShortX": ActionCGShortX,
+	"Div":      ActionDiv,
+	"DivX":     ActionDivX,
+	"IntInc":   ActionIntInc,
+	"IntIncX":  ActionIntIncX,
+	"ReInvDiv": ActionReInvDiv,
+	"ReInvInt": ActionReInvInt,
+	"ReInvLg":  ActionReInvLg,
+	"ReInvMd":  ActionReInvMd,
+	"ReInvSh":  ActionReInvSh,
+	"Reprice":  ActionReprice,
+	"XIn":      ActionXIn,
+	"XOut":     ActionXOut,
+	"MiscExp":  ActionMiscExp,
+	"MiscExpX": ActionMiscExpX,
+	"MiscInc":  ActionMiscInc,
+	"MiscIncX": ActionMiscIncX,
+	"MargInt":  ActionMarginInt,
+	"MargIntX": ActionMarginIntX,
+	"RtrnCap":  ActionReturnCap,
+	"RtrnCapX": ActionReturnCapX,
+	"StkSplit": ActionStockSplit,
+	"ShrsOut":  ActionSharesOut,
+	"ShrsIn":   ActionSharesIn,
+    }
+)
+
+// An InvestmentTransaction contains the information associated with
+// transactions for Investment accounts.
+type InvestmentTransaction interface {
+	Transaction
+
+	// Investment Action (Buy, Sell, etc.) as type InvestmentAction.
+	Action() InvestmentAction
+
+	// Investment Action (Buy, Sell, etc.) as type string.
+	ActionString() string
+
+	// Name of Security that was bought or sold (name of Stock, Fund, etc).
+	SecurityName() string
+
+	// Quantity of Shares (or split ratio, if Action is StkSplit).
+	Shares() decimal.Decimal
+
+	// Price which Investment Action was executed at.
+	Price() decimal.Decimal
+
+	// Commission cost (generally trades are commission-free these days).
+	Commission() decimal.Decimal
+}
+
+type investmentTransaction struct {
+	transaction
+	action		InvestmentAction
+	actionString	string
+	securityName	string
+	shares		decimal.Decimal
+	price		decimal.Decimal
+	commission	decimal.Decimal
+}
+
+func (t *investmentTransaction) Action() InvestmentAction {
+	return t.action
+}
+
+func (t *investmentTransaction) ActionString() string {
+	return t.actionString
+}
+
+func (t *investmentTransaction) SecurityName() string {
+	return t.securityName
+}
+
+func (t *investmentTransaction) Shares() decimal.Decimal {
+	return t.shares
+}
+
+func (t *investmentTransaction) Price() decimal.Decimal {
+	return t.price
+}
+
+func (t *investmentTransaction) Commission() decimal.Decimal {
+	return t.commission
+}
+
+func (t *investmentTransaction) parseInvestmentTransactionField(line string,
+	config Config) error {
+	if line == "" {
+		return errors.New("line is empty")
+	}
+
+	err := t.parseTransactionField(line, config)
+	if err == nil {
+		// Must have been a field from our embedded struct
+		return nil
+	}
+
+	if _, ok := err.(UnsupportedFieldError); !ok {
+		// An actual error happened
+		return err
+	}
+
+	// Otherwise, try and parse it here
+
+	switch line[0] {
+	case 'N':
+		t.actionString = line[1:]
+		t.action = actionMap[t.actionString]
+		return nil
+	case 'Y':
+		t.securityName = line[1:]
+		return nil
+	case 'Q':
+		shares := line[1:]
+		t.shares, err = decimal.NewFromString(shares)
+		return err
+	case 'I':
+		price := line[1:]
+		t.price, err = decimal.NewFromString(price)
+		return err
+	case 'O':
+		commission := line[1:]
+		t.commission, err = decimal.NewFromString(commission)
+		return err
+	default:
+		return UnsupportedFieldError(
+			errors.Errorf("cannot process line '%s'", line))
+	}
+}
+
+func (t *investmentTransaction) parseTransactionTypeField(line string,
+							  config Config) error {
+	return t.parseInvestmentTransactionField(line, config)
+}

--- a/investment_transaction_test.go
+++ b/investment_transaction_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package qif
+
+import (
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCheckAction(t *testing.T) {
+	tx := &investmentTransaction{}
+	const action = "Sell"
+
+	err := tx.parseInvestmentTransactionField("N"+action, Config{})
+	require.NoError(t, err)
+
+	assert.Equal(t, action, tx.ActionString())
+	assert.Equal(t, ActionSell, tx.Action())
+}
+
+func TestCheckPrice(t *testing.T) {
+	tx := &investmentTransaction{}
+	const price = "23.49"
+
+	err := tx.parseInvestmentTransactionField("I"+price, Config{})
+	require.NoError(t, err)
+
+	priceDecimal, _ := decimal.NewFromString(price)
+	assert.Equal(t, true, priceDecimal.Equal(tx.Price()))
+}
+
+func TestCheckShares(t *testing.T) {
+	tx := &investmentTransaction{}
+	const shares = "401"
+
+	err := tx.parseInvestmentTransactionField("Q"+shares, Config{})
+	require.NoError(t, err)
+
+	sharesDecimal, _ := decimal.NewFromString(shares)
+	assert.Equal(t, true, sharesDecimal.Equal(tx.Shares()))
+}

--- a/parse.go
+++ b/parse.go
@@ -25,6 +25,7 @@ const (
 	bankHeader = "!Type:Bank"
 	cashHeader = "!Type:Cash"
 	cardHeader = "!Type:CCard"
+	invstHeader = "!Type:Invst"
 	recordEnd  = "^"
 )
 
@@ -93,11 +94,13 @@ func (r *reader) parseHeader() error {
 	case bankHeader, cashHeader, cardHeader:
 		r.transactionType = TransactionTypeBanking
 		r.headerParsed = true
-		return nil
-
+	case invstHeader:
+		r.transactionType = TransactionTypeInvestment
+		r.headerParsed = true
 	default:
 		return errors.Errorf("unsupported header type '%s'", r.in.Text())
 	}
+	return nil
 }
 
 // Read implements Reader.Read.
@@ -112,8 +115,9 @@ func (r *reader) Read() (Transaction, error) {
 	}
 
 	// Parse type based on r.transactionType (set by parseHeader)
-	// Only one type supported at the moment
 	switch r.transactionType {
+	case TransactionTypeInvestment:
+		tx = &investmentTransaction{}
 	default:
 		tx = &bankingTransaction{}
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -113,7 +113,7 @@ func TestSpecExample1(t *testing.T) {
 			{Category: strptr("Mort Int"), Amount: intptr(-74636)},
 		},
 	}
-	expected1.date, err = time.Parse("1/ 2/06", "6/ 1/94")
+	expected1.date, err = time.ParseInLocation("1/ 2/06", "6/ 1/94", time.Local)
 	require.NoError(t, err)
 	expected1.amount = -100000
 	expected1.amountDecimal,_ = decimal.NewFromString("-1000.00")
@@ -121,7 +121,7 @@ func TestSpecExample1(t *testing.T) {
 	expected2 := &bankingTransaction{
 		payee: "Deposit",
 	}
-	expected2.date, err = time.Parse("1/ 2/06", "6/ 2/94")
+	expected2.date, err = time.ParseInLocation("1/ 2/06", "6/ 2/94", time.Local)
 	require.NoError(t, err)
 	expected2.amount = 7500
 	expected2.amountDecimal,_ = decimal.NewFromString("75.00")
@@ -131,7 +131,7 @@ func TestSpecExample1(t *testing.T) {
 		address:  []string{"P.O. Box 27027", "Tucson, AZ", "85726", "", ""},
 		category: "Entertain",
 	}
-	expected3.date, err = time.Parse("1/ 2/06", "6/ 3/94")
+	expected3.date, err = time.ParseInLocation("1/ 2/06", "6/ 3/94", time.Local)
 	require.NoError(t, err)
 	expected3.amount = -1000
 	expected3.amountDecimal,_ = decimal.NewFromString("-10.00")

--- a/parse_test.go
+++ b/parse_test.go
@@ -15,6 +15,7 @@
 package qif
 
 import (
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -115,6 +116,7 @@ func TestSpecExample1(t *testing.T) {
 	expected1.date, err = time.Parse("1/ 2/06", "6/ 1/94")
 	require.NoError(t, err)
 	expected1.amount = -100000
+	expected1.amountDecimal,_ = decimal.NewFromString("-1000.00")
 
 	expected2 := &bankingTransaction{
 		payee: "Deposit",
@@ -122,6 +124,7 @@ func TestSpecExample1(t *testing.T) {
 	expected2.date, err = time.Parse("1/ 2/06", "6/ 2/94")
 	require.NoError(t, err)
 	expected2.amount = 7500
+	expected2.amountDecimal,_ = decimal.NewFromString("75.00")
 
 	expected3 := &bankingTransaction{
 		payee:    "Anthony Hopkins",
@@ -131,6 +134,7 @@ func TestSpecExample1(t *testing.T) {
 	expected3.date, err = time.Parse("1/ 2/06", "6/ 3/94")
 	require.NoError(t, err)
 	expected3.amount = -1000
+	expected3.amountDecimal,_ = decimal.NewFromString("-10.00")
 	expected3.memo = "Film"
 
 	expected := []Transaction{expected1, expected2, expected3}

--- a/transaction.go
+++ b/transaction.go
@@ -28,6 +28,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+type TransactionType uint
+
+const (
+	TransactionTypeUndefined TransactionType = iota
+	TransactionTypeBanking
+)
+
 type ClearedStatus int
 
 const (
@@ -60,6 +67,8 @@ type Transaction interface {
 	// UnknownStatus if the transaction data did not specify a value for this
 	// field.
 	Status() ClearedStatus
+
+	parseTransactionTypeField(line string, config Config) error
 }
 
 type transaction struct {

--- a/transaction.go
+++ b/transaction.go
@@ -33,6 +33,7 @@ type TransactionType uint
 const (
 	TransactionTypeUndefined TransactionType = iota
 	TransactionTypeBanking
+	TransactionTypeInvestment
 )
 
 type ClearedStatus int

--- a/transaction.go
+++ b/transaction.go
@@ -222,7 +222,7 @@ func parseDate(s string, dayFirst bool) (date time.Time, err error) {
 	}
 
 	for _, f := range formats {
-		date, err = time.Parse(f, sMod)
+		date, err = time.ParseInLocation(f, sMod, time.Local)
 		if err == nil {
 			return
 		}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -28,10 +28,8 @@ func TestDateParse(t *testing.T) {
 	inputs := []string{
 		"1 March 2017",
 		"1 March 17",
-		"1 March '7",
 		"03/01/2017",
 		"03/01/17",
-		"03/01/'7",
 		"3/ 1/2017",
 		"03/1/2017",
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDateParse(t *testing.T) {
-	expectedDate, err := time.Parse("02/01/2006", "01/03/2017")
+	expectedDate, err := time.ParseInLocation("02/01/2006", "01/03/2017", time.Local)
 	require.NoError(t, err)
 
 	inputs := []string{
@@ -104,7 +104,7 @@ func TestBadTransactionLine(t *testing.T) {
 
 func TestParseTransactionDate(t *testing.T) {
 	const dateString = "31/12/99"
-	d, err := time.Parse("02/01/06", dateString)
+	d, err := time.ParseInLocation("02/01/06", dateString, time.Local)
 	require.NoError(t, err)
 
 	tx := &transaction{}


### PR DESCRIPTION
Finally sending this as pull request...!

I'm not expert with go interfaces, so maybe the part to determine which type of transactions are returned by ReadAll() could be done differently.  But this works for me.
ReadTransactionType() communicates if Banking or Investment transactions were returned.

Some other small things in this pull request.